### PR TITLE
Fix escaping of export symbols regex in Makefile

### DIFF
--- a/src/clevis/Makefile.am
+++ b/src/clevis/Makefile.am
@@ -3,4 +3,4 @@ clevispin_LTLIBRARIES = tang.la
 tang_la_SOURCES = common.c common.h acquire.c adv.c provision.c
 tang_la_CFLAGS = @CLEVIS_CFLAGS@
 tang_la_LIBADD = ../libcommon.la @CLEVIS_LIBS@
-tang_la_LDFLAGS = -module -avoid-version -export-symbols-regex '^clevis_pin\\$'
+tang_la_LDFLAGS = -module -avoid-version -export-symbols-regex '^clevis_pin$$'


### PR DESCRIPTION
Current definition of `tang_la_LDFLAGS` causes syntax error in shell script:

```
Makefile:414: update target 'tang.la' due to: tang_la-common.lo tang_la-acquire.lo tang_la-adv.lo tang_la-provision.lo ../libcommon.la
echo "  CCLD    " tang.la;/bin/sh ../../libtool --silent --tag=CC   --mode=link gcc -I/usr/local/include  -g -O2 -module -avoid-version -export-symbols-regex '^clevis_pin\\  -o tang.la -rpath /usr/local/lib/clevis tang_la-common.lo tang_la-acquire.lo tang_la-adv.lo tang_la-provision.lo ../libcommon.la -L/usr/local/lib -lclevis  
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

With this commit, the compile succeeds; the updated command being:

```
Makefile:414: update target 'tang.la' due to: tang_la-common.lo tang_la-acquire.
lo tang_la-adv.lo tang_la-provision.lo ../libcommon.la
echo "  CCLD    " tang.la;/bin/sh ../../libtool --silent --tag=CC   --mode=link gcc -I/usr/local/include  -g -O2 -module -avoid-version -export-symbols-regex '^clevis_pin$'  -o tang.la -rpath /usr/local/lib/clevis tang_la-common.lo tang_la-acquire.lo tang_la-adv.lo tang_la-provision.lo ../libcommon.la -L/usr/local/lib -lclevis
```

which appears correct (hopefully I am not off base, and the required symbols *are* exported).